### PR TITLE
Remove outdated banner text, use consistent protocol display

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,30 +15,8 @@
         <div class="usa-grid usa-banner-inner">
         <img src="assets/img/favicons/favicon-57.png" alt="U.S. flag">
         <p>An official website of the United States government</p>
-        <button class="usa-accordion-button usa-banner-button"
-          aria-expanded="false" aria-controls="gov-banner">
-          <span class="usa-banner-button-text">Here's how you know</span>
-        </button>
         </div>
       </header>
-      <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
-        <div class="usa-banner-guidance-gov usa-width-one-half">
-          <img class="usa-banner-icon usa-media_block-img" src="assets/img/icon-dot-gov.svg" alt="Dot gov">
-          <div class="usa-media_block-body">
-            <p>
-              <strong>The .gov means it’s official.</strong>
-              <br>
-              Federal government websites always use a .gov or .mil domain. Before sharing sensitive information online, make sure you’re on a .gov or .mil site by inspecting your browser’s address (or “location”) bar.
-            </p>
-          </div>
-        </div>
-        <div class="usa-banner-guidance-ssl usa-width-one-half">
-          <img class="usa-banner-icon usa-media_block-img" src="assets/img/icon-https.svg" alt="SSL">
-          <div class="usa-media_block-body">
-            <p>This site is also protected by an SSL (Secure Sockets Layer) certificate that’s been signed by the U.S. government. The <strong>https://</strong> means all transmitted data is encrypted  — in other words, any information or browsing history that you provide is transmitted securely.</p>
-          </div>
-        </div>
-      </div>
     </div>
   </div>
   <!-- Gov banner END -->
@@ -58,7 +36,7 @@
       </div>
       <div class="usa-width-two-thirds">
         <p>Looking for ConneCT, the State of Connecticut’s Department of Social Services?</p>
-        <p>Please visit <a href="https://connect.ct.gov/">https://connect.ct.gov/</a></p>
+        <p>Please visit <a href="https://connect.ct.gov/">https://connect.ct.gov</a></p>
       </div>
     </section>
     <section class="usa-grid usa-section">
@@ -66,7 +44,7 @@
         <h2>login.gov users:</h2>
       </div>
       <div class="usa-width-two-thirds">
-        <p>For access to federal websites, please visit <a href="https://www.login.gov">www.login.gov</a></p>
+        <p>For access to federal websites, please visit <a href="https://www.login.gov">https://www.login.gov</a></p>
       </div>
     </section>
   </main>


### PR DESCRIPTION
Removes some incorrect "Here's how you know" text, makes the two URLs use consistent formatting.